### PR TITLE
implement ORDER_INFO channel

### DIFF
--- a/cryptofeed/backends/backend.py
+++ b/cryptofeed/backends/backend.py
@@ -271,3 +271,15 @@ class BackendUserFillCallback:
         timestamp = kwargs.get('timestamp')
         receipt_timestamp = kwargs.get('receipt_timestamp')
         await self.write(feed, symbol, timestamp, receipt_timestamp, kwargs)
+
+
+class BackendUserOrderCallback:
+    async def __call__(self, *, feed, symbol, **kwargs):
+        for key in kwargs:
+            if isinstance(kwargs[key], Decimal):
+                kwargs[key] = self.numeric_type(kwargs[key])
+        kwargs['feed'] = feed
+        kwargs['symbol'] = symbol
+        timestamp = kwargs.get('timestamp')
+        receipt_timestamp = kwargs.get('receipt_timestamp')
+        await self.write(feed, symbol, timestamp, receipt_timestamp, kwargs)

--- a/cryptofeed/backends/zmq.py
+++ b/cryptofeed/backends/zmq.py
@@ -13,8 +13,8 @@ from cryptofeed.backends.backend import (BackendCandlesCallback, BackendQueue, B
                                          BackendLiquidationsCallback, BackendMarketInfoCallback,
                                          DeribitBackendBookCallback, DeribitBackendTickerCallback, DeribitBackendTradeCallback,
                                          BackendVolumeCallback, BackendUserBalanceCallback, BackendUserPositionCallback,
-                                         BackendUserFillCallback)
-from cryptofeed.defines import FUTURES_INDEX, TICKER, TRADES, USER_FILLS, VOLUME, USER_BALANCE, USER_POSITION
+                                         BackendUserFillCallback, BackendUserOrderCallback)
+from cryptofeed.defines import FUTURES_INDEX, TICKER, TRADES, USER_FILLS, VOLUME, USER_BALANCE, ORDER_INFO, USER_POSITION
 
 
 class ZMQCallback(BackendQueue):
@@ -101,3 +101,6 @@ class UserPositionZMQ(ZMQCallback, BackendUserPositionCallback):
 
 class UserFillZMQ(ZMQCallback, BackendUserFillCallback):
     default_key = USER_FILLS
+
+class OrderInfoZMQ(ZMQCallback, BackendUserOrderCallback):
+    default_key = ORDER_INFO


### PR DESCRIPTION
Implement FTX ORDER_INFO channel

Example: {'status': 'closed', 'order_id': 62487639845, 'side': 'buy', 'order_type': 'limit', 'avg_fill_price': None, 'filled_size': 0, 'remaining_size': 0, 'amount': Decimal('0.001'), 'timestamp': Decimal('1625618834.747608'), 'receipt_timestamp': Decimal('1625618834.747608'), 'feed': 'FTX', 'symbol': 'ETH-USD'}
